### PR TITLE
Neural/fix bookmark open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ build
 gqrx-scan
 
 .vscode/c_cpp_properties.json
+.vscode/c_cpp_properties.json

--- a/gqrx-scan.c
+++ b/gqrx-scan.c
@@ -1389,9 +1389,12 @@ int main(int argc, char **argv) {
     strcpy (to,   print_freq(opt_max_freq));
     printf ("Frequency range set from %s to %s.\n", from, to);
     
-    bookmarksfd = Open(g_bookmarksfile);
-    LoadFrequencies (bookmarksfd);
-
+    if (opt_scan_mode == bookmark)
+    {
+        bookmarksfd = Open(g_bookmarksfile);
+        LoadFrequencies (bookmarksfd);
+    }
+    
     if (opt_tag_search)
     {
         char str [1024];


### PR DESCRIPTION
Remove the requirement for a bookmark file when using the sweep mode.