### PR TITLE
Add option to record detected signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In sweep mode the scan of the band is performed fast (well, as fast as it can), 
 * Multiple Tag based search in bookmark scan mode ("Tag1|Tag2|TagX").
 * Automatic Frequency Locking in sweep scan mode
 * Interactive monitor to skip, ban or pause a frequency manually
+* Automatic recording of detected signals
 
 ## Pre-requisites
 Gqrx Remote Protocol must be enabled: Tools->Remote Control. See [this](http://gqrx.dk/doc/remote-control).
@@ -38,11 +39,14 @@ I have found better result with high fft size (64536) and 17 fps refresh rate, b
 ## Command line Options
 ```
 Usage:
-gqrx-scanner	[-h|--host <host>] [-p|--port <port>] [-m|--mode <sweep|bookmark>]
+./gqrx-scanner
+		[-h|--host <host>] [-p|--port <port>] [-m|--mode <sweep|bookmark>]
 		[-f <central frequency>] [-b|--min <from freq>] [-e|--max <to freq>]
 		[-d|--delay <lingering time in milliseconds>]
+		[-l|--max-listen <maximum listening time in milliseconds>]
 		[-t|--tags <"tag1|tag2|...">]
 		[-v|--verbose]
+		[-r|--record]
 
 -h, --host <host>            Name of the host to connect. Default: localhost
 -p, --port <port>            The number of the port to connect. Default: 7356
@@ -50,20 +54,21 @@ gqrx-scanner	[-h|--host <host>] [-p|--port <port>] [-m|--mode <sweep|bookmark>]
                                Possible values for <mode>: sweep, bookmark
 -f, --freq <freq>            Frequency to scan with a range of +- 1MHz.
                                Default: the current frequency tuned in Gqrx Incompatible with -b, -e
--s, --step <freq>            Frequency step <freq> in Hz. Default: 10000
 -b, --min <freq>             Frequency range begins with this <freq> in Hz. Incompatible with -f
 -e, --max <freq>             Frequency range ends with this <freq> in Hz. Incompatible with -f
+-s, --step <freq>            Frequency step <freq> in Hz. Default: 10000
 -d, --delay <time>           Lingering time in milliseconds before the scanner reactivates. Default 2000
--l, --max-listen <time>      Maximum time to listen to a frequency, active or otherwise. Default 0, no maximum time
+-l, --max-listen <time>      Maximum time to listen to an active frequency. Default 0, no maximum
 -x, --speed <time>           Time in milliseconds for bookmark scan speed. Default 250 milliseconds.
                                If scan lands on wrong bookmark during search, use -x 500 (ms) to slow down speed
 -y  --date                   Date Format, default is 0.
                                0 = mm-dd-yy
                                1 = dd-mm-yy
--q, --squelch_delta <dB>     If set creates bottom squelch just
-                             for listening. It may reduce unnecessary squelch audio supress.
+-q, --squelch_delta <dB>|a<dB> If set creates bottom squelch just for listening.
+                             It may reduce unnecessary squelch audio supress.
                              Default: 0.0
-                             Place \"a\" switch before <dB> value to turn into auto mode.
+                             Ex.: 6.5
+                             Place "a" switch before <dB> value to turn into auto mode
                              It will determine squelch delta based on noise floor and
                              <dB> value will determine how far squelch delta will be placed from it.
                              Ex.: a0.5
@@ -71,6 +76,7 @@ gqrx-scanner	[-h|--host <host>] [-p|--port <port>] [-m|--mode <sweep|bookmark>]
                                "tags" is a quoted string with a '|' list separator: Ex: "Tag1|Tag2"
                                tags are case insensitive and match also for partial string contained in a tag
                                Works only with -m bookmark scan mode
+-r, --record                 Enable recording of detected signals
 -v, --verbose                Output more information during scan (used for debug). Default: false
 --help                       This help message.
 
@@ -153,6 +159,4 @@ sudo make uninstall
 
 ## TODOs
 * set modulation in bookmark search
-* automatic audio recording on signal detection
 * parsable output in csv?
-

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I have found better result with high fft size (64536) and 17 fps refresh rate, b
 ## Command line Options
 ```
 Usage:
-./gqrx-scanner
+gqrx-scanner
 		[-h|--host <host>] [-p|--port <port>] [-m|--mode <sweep|bookmark>]
 		[-f <central frequency>] [-b|--min <from freq>] [-e|--max <to freq>]
 		[-d|--delay <lingering time in milliseconds>]

--- a/gqrx-prot.c
+++ b/gqrx-prot.c
@@ -59,7 +59,6 @@ int Connect (char *hostname, int portno)
     struct sockaddr_in serveraddr;
     struct hostent *server;
 
-
     /* socket: create the socket */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0)
@@ -214,5 +213,39 @@ bool GetSignalLevelEx(int sockfd, double *dBFS, int n_samp)
         usleep(1000);
     }
     *dBFS = *dBFS / (n_samp - errors);
+    return true;
+}
+
+//
+// StartRecording
+// Start recording audio stream to a file
+//
+bool StartRecording(int sockfd)
+{
+    char buf[BUFSIZE];
+
+    Send(sockfd, "U RECORD 1\n");
+    Recv(sockfd, buf);
+
+    if (strcmp(buf, "RPRT 1") == 0 )
+        return false;
+
+    return true;
+}
+
+//
+// StopRecording
+// Stop recording audio stream
+//
+bool StopRecording(int sockfd)
+{
+    char buf[BUFSIZE];
+
+    Send(sockfd, "U RECORD 0\n");
+    Recv(sockfd, buf);
+
+    if (strcmp(buf, "RPRT 1") == 0 )
+        return false;
+
     return true;
 }

--- a/gqrx-prot.h
+++ b/gqrx-prot.h
@@ -61,7 +61,7 @@ bool GetSignalLevel(int sockfd, double *dBFS);
 bool GetSquelchLevel(int sockfd, double *dBFS);
 bool SetSquelchLevel(int sockfd, double dBFS);
 bool GetSignalLevelEx(int sockfd, double *dBFS, int n_samp);
-
-
+bool StartRecording(int sockfd);
+bool StopRecording(int sockfd);
 
 #endif /* _GQRX_PROT_H_ */

--- a/gqrx-scan.c
+++ b/gqrx-scan.c
@@ -163,7 +163,7 @@ void print_usage ( char *name )
     printf ("\t\t[-l|--max-listen <maximum listening time in milliseconds>]\n");
     printf ("\t\t[-t|--tags <\"tag1|tag2|...\">]\n");
     printf ("\t\t[-v|--verbose]\n");
-    printf ("\t\t[-r|--record] (enables recording of found signals)\n");
+    printf ("\t\t[-r|--record]\n");
     printf ("\n");
     printf ("-h, --host <host>            Name of the host to connect. Default: localhost\n");
     printf ("-p, --port <port>            The number of the port to connect. Default: 7356\n");
@@ -193,6 +193,7 @@ void print_usage ( char *name )
     printf ("                               \"tags\" is a quoted string with a '|' list separator: Ex: \"Tag1|Tag2\"\n");
     printf ("                               tags are case insensitive and match also for partial string contained in a tag\n");
     printf ("                               Works only with -m bookmark scan mode\n");
+    printf ("-r, --record                  Enable recording of detected signals\n");
     //printf ("\t\t[-x|--disable-sweep-store] [-s <min hit>] [-m <max miss>]
     printf ("-v, --verbose                Output more information during scan (used for debug). Default: false\n");
     printf ("--help                       This help message.\n");

--- a/gqrx-scan.c
+++ b/gqrx-scan.c
@@ -984,6 +984,7 @@ bool ScanBookmarkedFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_m
                     GetSignalLevelEx(sockfd, &level, 5 );
                     if (level >= squelch)
                     {
+                        StartRecording(sockfd);
                         time_t hit_time = GetTime(timestamp);
                         if (opt_squelch_delta_auto_enable)
                         {
@@ -1002,6 +1003,7 @@ bool ScanBookmarkedFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_m
                         fflush(stdout);
                         skip = WaitUserInputOrDelay(sockfd, opt_delay, &current_freq);
                         time_t elapsed = DiffTime(timestamp, hit_time);
+                        StopRecording(sockfd);
                         printf (" [elapsed time %s]\n", timestamp);
                         if (opt_squelch_delta_auto_enable) SetSquelchLevel(sockfd, squelch_backup);
                         fflush(stdout);
@@ -1365,7 +1367,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
     int  success_counter    = 0;  // number of correctly acquired signals, reset on bad signals or reaching success_factor
     int  success_factor     = 5; // improving sleep cycle every success_factor of times
 
-    while (true)
+    while (current_freq <= freq_max)
     {
         for ( size_t i = 0 ; i < freqeuencies_count; i++)
         {
@@ -1449,6 +1451,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
                 else
                 {
                     SaveFreq(current_freq);
+                    StartRecording(sockfd); // Add here - after confirming valid signal
                     if (opt_squelch_delta_auto_enable){
                         squelch_backup = squelch;
                         SetSquelchLevel(sockfd, Frequencies[i].noise_floor + squelch_delta);
@@ -1471,6 +1474,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
                     // Wait user input or delay time after signal lost
                     skip = WaitUserInputOrDelay(sockfd, opt_delay, &current_freq);
                     time_t elapsed = DiffTime(timestamp, hit_time);
+                    StopRecording(sockfd); // Add here - before moving to next frequency
                     printf (" [elapsed time %s]\n", timestamp);
                     fflush(stdout);
                     if (opt_squelch_delta_auto_enable) SetSquelchLevel(sockfd, squelch_backup);
@@ -1536,6 +1540,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
             sweep_count++;
         }
     }
+    return true;
 }
 
 

--- a/gqrx-scan.c
+++ b/gqrx-scan.c
@@ -1380,7 +1380,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
     int  success_counter    = 0;  // number of correctly acquired signals, reset on bad signals or reaching success_factor
     int  success_factor     = 5; // improving sleep cycle every success_factor of times
 
-    while (current_freq <= freq_max)
+    while (true)
     {
         for ( size_t i = 0 ; i < freqeuencies_count; i++)
         {

--- a/gqrx-scan.c
+++ b/gqrx-scan.c
@@ -136,7 +136,7 @@ char           *opt_tags[TAG_MAX] = {0};
 int             opt_tag_max = 0;
 bool            opt_disable_store = false;
 long            opt_max_listen = 0;
-bool            opt_record_enabled = false;
+bool            opt_record = false;
 // only for debug
 bool            opt_verbose = false;
 
@@ -499,7 +499,7 @@ bool ParseInputOptions (int argc, char **argv)
                 }
                 break;
             case 'r':
-                opt_record_enabled = true;
+                opt_record = true;
                 break;
             case '?':
             /* getopt_long already printed an error message. */
@@ -991,7 +991,7 @@ bool ScanBookmarkedFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_m
                     GetSignalLevelEx(sockfd, &level, 5 );
                     if (level >= squelch)
                     {
-                        if (opt_record_enabled)
+                        if (opt_record)
                         {
                             StartRecording(sockfd);
                         }
@@ -1013,7 +1013,7 @@ bool ScanBookmarkedFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_m
                         fflush(stdout);
                         skip = WaitUserInputOrDelay(sockfd, opt_delay, &current_freq);
                         time_t elapsed = DiffTime(timestamp, hit_time);
-                        if (opt_record_enabled)
+                        if (opt_record)
                         {
                             StopRecording(sockfd);
                         }
@@ -1464,7 +1464,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
                 else
                 {
                     SaveFreq(current_freq);
-                    if (opt_record_enabled)
+                    if (opt_record)
                     {
                         StartRecording(sockfd);
                     }
@@ -1490,7 +1490,7 @@ bool ScanFrequenciesInRange(int sockfd, freq_t freq_min, freq_t freq_max, freq_t
                     // Wait user input or delay time after signal lost
                     skip = WaitUserInputOrDelay(sockfd, opt_delay, &current_freq);
                     time_t elapsed = DiffTime(timestamp, hit_time);
-                    if (opt_record_enabled)
+                    if (opt_record)
                     {
                         StopRecording(sockfd);
                     }


### PR DESCRIPTION
This PR adds a `-r` / `--record` argument to allow the user to record detected signals in the folder defined in GQRX.